### PR TITLE
Remove pin_arduino.h include

### DIFF
--- a/nRF51822-BLEMIDI/nRF51822-BLEMIDI.ino
+++ b/nRF51822-BLEMIDI/nRF51822-BLEMIDI.ino
@@ -20,11 +20,9 @@
  *  SOFTWARE.
  */
 
-#include <pins_arduino.h>
 #include <Arduino.h>
 #include <BLE_API.h>
 #include <nordic_common.h>
-//#include <SPI.h>
 #include <Usb.h>
 #include <usbh_midi.h>
 #include "BLEParser.h"


### PR DESCRIPTION
This is unused and will lead to compilation errors on Windows.

Adresses https://github.com/sieren/blidino/issues/10
